### PR TITLE
Modify region name in python code 

### DIFF
--- a/ec2_list.py
+++ b/ec2_list.py
@@ -1,6 +1,6 @@
 # This function is written to get list of EC2 instances as Dictionary Object in Python
 import boto3
-ec2 = boto3.client('ec2',region_name="ap-south-1")
+ec2 = boto3.client('ec2',region_name="us-west-2")
 
 ec2_dict=ec2.describe_instances()
 print("ec2_dict type is",type(ec2_dict))

--- a/merge.txt
+++ b/merge.txt
@@ -1,0 +1,1 @@
+1st line content in merge.txt

--- a/merge.txt
+++ b/merge.txt
@@ -1,1 +1,2 @@
 1st line content in merge.txt
+appended some lines to merge.txt


### PR DESCRIPTION
- Changes done to modify the region name as us-west-2 instead of ap-south-1